### PR TITLE
Fix page-get-revision

### DIFF
--- a/mediawiki.el
+++ b/mediawiki.el
@@ -1166,10 +1166,10 @@ return the whole revision structure."
   (let ((rev (cdr (nth revision (cddr (assq 'revisions (cddr page)))))))
     (cond
      ((eq bit 'content)
-      (cadr revision))
-     ((assoc bit (car revision))
-      (cdr (assoc bit (car revision))))
-     (t revision))))
+      (cadr rev))
+     ((assoc bit (car rev))
+      (cdr (assoc bit (car rev))))
+     (t rev))))
 
 (defun mediawiki-pagelist-find-page (pagelist title)
   "Given PAGELIST, extract the informaton for TITLE."


### PR DESCRIPTION
(confusing rev and revision variables, see https://github.com/hexmode/mediawiki-el/issues/2).

I am a little confused, but I hope this fixes issue #2.

When looking at mediawiki.el (https://github.com/hexmode/mediawiki-el/blob/master/mediawiki.el#L1177), the return value of mediawiki-page-get-revision uses the 'revision' variable (an integer) instead of 'rev' which is the actual revision (I believe of type listp).  But when looking at the diff of this pull request, the original mediawiki.el file (from hexmode/mediawiki-el) seems to have the correct variable used (rev instead of revision).  So, please discard this if it is not relevant.