### PR TITLE
Fix syntax error (unbalanced parentheses)

### DIFF
--- a/mediawiki.el
+++ b/mediawiki.el
@@ -987,12 +987,12 @@ Right now, this only means replacing \"_\" with \" \"."
 ACTION is the API action.  ARGS is a list of arguments."
   (let* ((raw (url-http-post (mediawiki-make-api-url sitename)
                              (append args (list (cons "format" "xml")
-                                                (cons "action" action))))
-              (string= action "upload")))
+                                                (cons "action" action)))
+                             (string= action "upload")))
          (result (assoc 'api
-                            (with-temp-buffer
-                              (insert raw)
-                              (xml-parse-region (point-min) (point-max))))))
+                        (with-temp-buffer
+                          (insert raw)
+                          (xml-parse-region (point-min) (point-max))))))
     (unless result
       (error "There was an error parsing the result of the API call"))
 


### PR DESCRIPTION
The change in c41180d6f7c42df5051a520eabc7d00bf8816a70 did not remove
the closing paren after removing '(delq nil'.