### PR TITLE
Fall back to token API of <mediawiki-1.27.

### DIFF
--- a/mediawiki.el
+++ b/mediawiki.el
@@ -1389,7 +1389,7 @@ Store cookies for future authentication."
                             (read-string "LDAP Domain: ")
                           dom-loaded)))
                  (sitename sitename)
-                 (token (mediawiki-site-get-token sitename "login"))
+                 (token (ignore-error (mediawiki-site-get-token sitename "login")))
                  (args (list (cons "lgname" user)
                              (cons "lgpassword" pass)
                              (when token


### PR DESCRIPTION
On <mediawiki-1.27, the mediawiki-site-get-token will fail.  The old
action=login POST method is used instead to obtain login tokens.

Closes: https://github.com/hexmode/mediawiki-el/issues/28