### PR TITLE
Default user-agent to "" if url-user-agent isn’t a string or function

### DIFF
--- a/mediawiki.el
+++ b/mediawiki.el
@@ -414,10 +414,14 @@ Some provision is made for different versions of Emacs version.
 POST-PROCESS is the function to call for post-processing.
 BUFFER is the buffer to store the result in.  CALLBACK will be
 called in BUFFER with CBARGS, if given."
-  (let ((url-user-agent (concat (string-trim (if (functionp url-user-agent)
-                                                 (funcall url-user-agent)
-                                               url-user-agent))
-                                " mediawiki.el " mediawiki-version "\r\n")))
+  (let ((url-user-agent
+         (concat (string-trim (cond
+                               ((functionp url-user-agent)
+                                (funcall url-user-agent))
+                               ((stringp url-user-agent)
+                                url-user-agent)
+                               (t "")))
+                 " mediawiki.el " mediawiki-version "\r\n")))
     (cond ((boundp 'url-be-asynchronous) ; Sniff w3 lib capability
            (if callback
                (setq url-be-asynchronous t)


### PR DESCRIPTION
Emacs changed the default value for `url-user-agent` to `'default` in [this commit](https://github.com/emacs-mirror/emacs/commit/234ef3b432b7dff6629a12be5dd03a163b8e8619), but this package still expects it to be either a string or a function returning a string. The variable can now be that symbol or `nil`, in addition to the previous possible types.

This PR changes the package to use the empty string as a user-agent string in the two new cases. I don’t think this is correct behaviour, but it allows the package to open mediawiki sites without crashing, so it's a quick improvement at least.

(Fixes #27)